### PR TITLE
[DOC FIX] Refactoring autodoc module discovery

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -68,5 +68,6 @@ Terminedia
 ===========
 .. automodule:: terminedia
    :members:
+   :imported-members:
    :undoc-members:
    :special-members: __init__,__enter__,__exit__,__contains__


### PR DESCRIPTION
Given the sphinx documentation, the **auto-discovery** is not a supported feature yet. Since the `__init__.py` explicitly import the refactored modules, we must add the `imported-members` directive into the RST file.

http://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_default_options